### PR TITLE
Fix trailing capitals splitting at camel case style words

### DIFF
--- a/autoload/spelunker.vim
+++ b/autoload/spelunker.vim
@@ -147,10 +147,10 @@ function! s:code_to_words(line_of_code)
 
 	" ABCdef -> AB Cdef
 	" abcAPI -> abc API
-  " abcD -> abc D
-  let l:code_for_split = substitute(l:code_for_split,
-        \ '\v(([A-Z\s]@<![A-Z]|[A-Z][a-z])|([A-Z]+$))\C',
-        \ l:split_by . "\\1", "g")
+	" abcD -> abc D
+	let l:code_for_split = substitute(l:code_for_split,
+		\ '\v(([A-Z\s]@<![A-Z]|[A-Z][a-z])|([A-Z]+$))\C',
+		\ l:split_by . "\\1", "g")
 
 	" AA__BB -> AA  BB -> AA BB
 	let l:code_for_split = substitute(l:code_for_split, '\v\s+', l:split_by, "g")

--- a/autoload/spelunker.vim
+++ b/autoload/spelunker.vim
@@ -147,7 +147,7 @@ function! s:code_to_words(line_of_code)
 
 	" ABCdef -> AB Cdef
 	" abcAPI -> abc API
-	" let l:code_for_split = substitute(l:code_for_split, '\v([A-Z\s]@<![A-Z]|[A-Z][a-z])\C', l:split_by . "\\1", "g")
+  " abcD -> abc D
   let l:code_for_split = substitute(l:code_for_split,
         \ '\v(([A-Z\s]@<![A-Z]|[A-Z][a-z])|([A-Z]+$))\C',
         \ l:split_by . "\\1", "g")

--- a/autoload/spelunker.vim
+++ b/autoload/spelunker.vim
@@ -147,7 +147,10 @@ function! s:code_to_words(line_of_code)
 
 	" ABCdef -> AB Cdef
 	" abcAPI -> abc API
-	let l:code_for_split = substitute(l:code_for_split, '\v([A-Z\s]@<![A-Z]|[A-Z][a-z])\C', l:split_by . "\\1", "g")
+	" let l:code_for_split = substitute(l:code_for_split, '\v([A-Z\s]@<![A-Z]|[A-Z][a-z])\C', l:split_by . "\\1", "g")
+  let l:code_for_split = substitute(l:code_for_split,
+        \ '\v(([A-Z\s]@<![A-Z]|[A-Z][a-z])|([A-Z]+$))\C',
+        \ l:split_by . "\\1", "g")
 
 	" AA__BB -> AA  BB -> AA BB
 	let l:code_for_split = substitute(l:code_for_split, '\v\s+', l:split_by, "g")


### PR DESCRIPTION
I'm using this plugin for some time and I like it! However, I noticed small problem while using particular naming convention at my current project. While parsing words plugin treats camel case words like `fooBarF` as `foo BarF` which results in `BarF` highlighted as spelling error. Probably, correct word splitting should be `foo Bar F`. Basically, described behavior is edge case for camel case word with abbreviation inside `fooHTMLBar` (which is handled correctly right now: `foo HTML Bar`).

This PR forces outlined behavior by default. But it can be made optional/configurable if old behavior is correct one.

Thanks and enjoy your day!