### PR TITLE
Add basic support for elixir

### DIFF
--- a/autoload/spelunker/white_list.vim
+++ b/autoload/spelunker/white_list.vim
@@ -32,6 +32,9 @@ function! spelunker#white_list#init_white_list()
 		" Ruby: http://secret-garden.hatenablog.com/entry/2015/06/30/000000
 		let l:wl += ['nil', 'def', 'undef']
 
+		" Elixir
+		let l:wl += ['defp', 'defimpl', 'defmacro', 'defmacrop', 'defmodule', 'defprotocol', 'defstruct']
+
 		" C: https://ja.wikipedia.org/wiki/キーワード_(C言語)
 		let l:wl += ['typedef', 'noreturn']
 


### PR DESCRIPTION
Prevent spelunker to display Elixir reserved words as misspelled 