### PR TITLE
fix: getting error on check_displayed_words #40

### DIFF
--- a/autoload/spelunker/matches.vim
+++ b/autoload/spelunker/matches.vim
@@ -70,13 +70,15 @@ function! spelunker#matches#delete_matches(word_list_for_delete, match_id_dict, 
 				let l:is_ok = matchdelete(l:delete_match_id, a:window_id)
 
 				if l:is_ok == -1 && a:window_id == win_getid()
+					" vimでmatchdeleteの第2引数が効かない場合はこちら
 					" Vimでも第2引数がある場合に上手く削除できない不具合があった時期があったため
 					let l:is_ok = matchdelete(l:delete_match_id)
 				endif
 			catch
-				" nvimでmatchdeleteの第2引数が効かない
+				" Issue: #35, #40
+				" nvimでmatchdeleteの第2引数が効かない場合はこちら
 				" FYI: https://github.com/neovim/neovim/issues/12110
-				if a:window_id == win_getid()
+				if spelunker#matches#is_exist_match_id(l:delete_match_id) && a:window_id == win_getid()
 					" 第2引数がある場合に上手く削除できない不具合があった時期があったため
 					let l:is_ok = matchdelete(l:delete_match_id)
 				endif
@@ -116,6 +118,17 @@ function! spelunker#matches#clear_current_buffer_matches()
 	endif
 endfunction
 
+function spelunker#matches#is_exist_match_id(match_id)
+	let l:matches = getmatches()
+
+	for l:match in l:matches
+		if l:match['id'] == a:match_id
+			return v:true
+		endif
+	endfor
+
+	return v:false
+endfunction
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/spelunker/matches.vim
+++ b/autoload/spelunker/matches.vim
@@ -118,7 +118,7 @@ function! spelunker#matches#clear_current_buffer_matches()
 	endif
 endfunction
 
-function spelunker#matches#is_exist_match_id(match_id)
+function! spelunker#matches#is_exist_match_id(match_id)
 	let l:matches = getmatches()
 
 	for l:match in l:matches

--- a/autoload/spelunker/test/test_match.vim
+++ b/autoload/spelunker/test/test_match.vim
@@ -15,6 +15,7 @@ function! spelunker#test#test_match#test()
 
 	call s:test_clear_matches()
 	call s:test_clear_buffer_matches()
+	call s:test_is_exist_match_id()
 endfunction
 
 function! s:test_get_match_pattern()
@@ -94,6 +95,21 @@ function! s:test_clear_buffer_matches()
 	call assert_notequal({}, b:match_id_dict[l:win_id])
 	call spelunker#matches#clear_current_buffer_matches()
 	call assert_equal({l:win_id: {}}, b:match_id_dict)
+endfunction
+
+function! s:test_is_exist_match_id()
+	call spelunker#test#open_unit_test_buffer('match', 'clear_matches.txt')
+
+	let l:win_id = win_getid()
+	let b:match_id_dict = {}
+	let [l:word_list_for_delete_match, b:match_id_dict[l:win_id]]
+			\ = spelunker#matches#add_matches(['appl', 'orangg', 'banna'], {})
+
+	call assert_notequal(v:true, spelunker#matches#is_exist_match_id(4))
+	call assert_notequal(v:false, spelunker#matches#is_exist_match_id(99999999))
+
+	call spelunker#matches#clear_current_buffer_matches()
+	call assert_notequal(v:false, spelunker#matches#is_exist_match_id(4))
 endfunction
 
 let &cpo = s:save_cpo

--- a/autoload/spelunker/test/test_match.vim
+++ b/autoload/spelunker/test/test_match.vim
@@ -105,11 +105,14 @@ function! s:test_is_exist_match_id()
 	let [l:word_list_for_delete_match, b:match_id_dict[l:win_id]]
 			\ = spelunker#matches#add_matches(['appl', 'orangg', 'banna'], {})
 
-	call assert_notequal(v:true, spelunker#matches#is_exist_match_id(4))
-	call assert_notequal(v:false, spelunker#matches#is_exist_match_id(99999999))
+	let l:exist_match_id = b:match_id_dict[l:win_id]['appl']
+	call assert_equal(v:true, spelunker#matches#is_exist_match_id(l:exist_match_id))
+	call assert_equal(v:false, spelunker#matches#is_exist_match_id(99999999))
 
-	call spelunker#matches#clear_current_buffer_matches()
-	call assert_notequal(v:false, spelunker#matches#is_exist_match_id(4))
+	call clearmatches()
+	call assert_equal(v:false, spelunker#matches#is_exist_match_id(l:exist_match_id))
+
+	call spelunker#matches#clear_matches()
 endfunction
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Unit test was successful, but getting error when scrolling. (#39)
The best way is to fix neovim matchdelete() function as same as Vim8, but this pull request would be support for current nvim version. (v0.4.3) 