### PR TITLE
Effect `g:enable_spelunker_vim_on_readonly` option for `nomodifiable`

### DIFF
--- a/autoload/spelunker.vim
+++ b/autoload/spelunker.vim
@@ -216,7 +216,7 @@ function s:is_runnable()
 		return 0
 	endif
 
-	if g:enable_spelunker_vim_on_readonly == 0 && ( &readonly || !&modifiable )
+	if g:enable_spelunker_vim_on_readonly == 0 && ( &readonly || !&modifiable || &filetype ==# 'qf' )
 		return 0
 	endif
 

--- a/autoload/spelunker.vim
+++ b/autoload/spelunker.vim
@@ -216,7 +216,7 @@ function s:is_runnable()
 		return 0
 	endif
 
-	if g:enable_spelunker_vim_on_readonly == 0 && &readonly
+	if g:enable_spelunker_vim_on_readonly == 0 && ( &readonly || !&modifiable )
 		return 0
 	endif
 


### PR DESCRIPTION
Besides `readonly`, shouldn't it consider `nomodifiable` setting?

Some plugins may set only `nomodifiable` without `readonly` for no-modification-expected buffers
(e.g. [fugitive](https://github.com/tpope/vim-fugitive) `G log` window).