### PR TITLE
Fix: Set spellcheck highlighting on every spellcheck enabling

### DIFF
--- a/autoload/spelunker/toggle.vim
+++ b/autoload/spelunker/toggle.vim
@@ -52,9 +52,9 @@ function! spelunker#toggle#set_syntax()
 	finally
 		if strlen(l:spelunker_complex_or_compound_word_hi_list) == 0 || l:spelunker_complex_or_compound_word_hi_list =~# '\v<cleared>$'
 			if s:spelunker_complex_or_compound_word_style =~# '^links to\>'
-				execute('highlight link' . g:spelunker_complex_or_compound_word_group . ' ' . substitute(s:spelunker_complex_or_compound_word_style), '^links to\s*', '', ''))
+				execute('highlight link ' . g:spelunker_complex_or_compound_word_group . ' ' . substitute(s:spelunker_complex_or_compound_word_style, '^links to\s*', '', ''))
 			else
-				execute('highlight '     . g:spelunker_complex_or_compound_word_group . ' ' .            s:spelunker_complex_or_compound_word_style)
+				execute('highlight '      . g:spelunker_complex_or_compound_word_group . ' ' .            s:spelunker_complex_or_compound_word_style)
 			endif
 		else
 			let s:spelunker_complex_or_compound_word_style = substitute(trim(l:spelunker_complex_or_compound_word_hi_list), '^\V' . g:spelunker_complex_or_compound_word_group . '\v\s+xxx\+', '', '')

--- a/autoload/spelunker/toggle.vim
+++ b/autoload/spelunker/toggle.vim
@@ -15,13 +15,19 @@ function! spelunker#toggle#set_syntax()
 		let g:spelunker_spell_bad_group = 'SpelunkerSpellBad'
 	endif
 
+	if !exists('s:spelunker_spell_bad_style')
+		let s:spelunker_spell_bad_style = 'cterm=underline ctermfg=247 gui=underline guifg=#9E9E9E'
+	endif
+
 	let l:spelunker_spell_bad_hi_list = ""
 	try
-	let l:spelunker_spell_bad_hi_list = execute('highlight ' . g:spelunker_spell_bad_group)
+		let l:spelunker_spell_bad_hi_list = execute('highlight ' . g:spelunker_spell_bad_group)
 	catch
 	finally
 		if strlen(l:spelunker_spell_bad_hi_list) == 0 || l:spelunker_spell_bad_hi_list =~# '\v<cleared>$'
-			execute ('highlight ' . g:spelunker_spell_bad_group . ' cterm=underline ctermfg=247 gui=underline guifg=#9E9E9E')
+			execute ('highlight ' . g:spelunker_spell_bad_group . ' ' . s:spelunker_spell_bad_style)
+		else
+			let s:spelunker_spell_bad_style = substitute(trim(l:spelunker_spell_bad_hi_list), '^\V' . g:spelunker_spell_bad_group . '\v\s+xxx\s+', '', '')
 		endif
 	endtry
 
@@ -31,13 +37,19 @@ function! spelunker#toggle#set_syntax()
 		let g:spelunker_complex_or_compound_word_group = 'SpelunkerComplexOrCompoundWord'
 	endif
 
+	if !exists('s:spelunker_complex_or_compound_word_style')
+		let s:spelunker_complex_or_compound_word_style = 'cterm=underline ctermfg=NONE gui=underline guifg=NONE'
+	endif
+
 	let l:spelunker_complex_or_compound_word_hi_list = ""
 	try
 		let l:spelunker_complex_or_compound_word_hi_list = execute('highlight ' . g:spelunker_complex_or_compound_word_group)
 	catch
 	finally
 		if strlen(l:spelunker_complex_or_compound_word_hi_list) == 0 || l:spelunker_complex_or_compound_word_hi_list =~# '\v<cleared>$'
-			execute ('highlight ' . g:spelunker_complex_or_compound_word_group . ' cterm=underline ctermfg=NONE gui=underline guifg=NONE')
+			execute ('highlight ' . g:spelunker_complex_or_compound_word_group . ' ' . s:spelunker_complex_or_compound_word_style)
+		else
+			let s:spelunker_complex_or_compound_word_style = substitute(trim(l:spelunker_complex_or_compound_word_hi_list), '^\V' . g:spelunker_complex_or_compound_word_group . '\v\s+xxx\+', '', '')
 		endif
 	endtry
 endfunction

--- a/autoload/spelunker/toggle.vim
+++ b/autoload/spelunker/toggle.vim
@@ -8,6 +8,40 @@ scriptencoding utf-8
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! spelunker#toggle#set_syntax()
+	" [spelunker_spell_bad_group] ===========================================================
+
+	if !exists('g:spelunker_spell_bad_group')
+		let g:spelunker_spell_bad_group = 'SpelunkerSpellBad'
+	endif
+
+	let l:spelunker_spell_bad_hi_list = ""
+	try
+	let l:spelunker_spell_bad_hi_list = execute('highlight ' . g:spelunker_spell_bad_group)
+	catch
+	finally
+		if strlen(l:spelunker_spell_bad_hi_list) == 0 || l:spelunker_spell_bad_hi_list =~# '\v<cleared>$'
+			execute ('highlight ' . g:spelunker_spell_bad_group . ' cterm=underline ctermfg=247 gui=underline guifg=#9E9E9E')
+		endif
+	endtry
+
+	" [spelunker_complex_or_compound_word_group] =======================================================
+
+	if !exists('g:spelunker_complex_or_compound_word_group')
+		let g:spelunker_complex_or_compound_word_group = 'SpelunkerComplexOrCompoundWord'
+	endif
+
+	let l:spelunker_complex_or_compound_word_hi_list = ""
+	try
+		let l:spelunker_complex_or_compound_word_hi_list = execute('highlight ' . g:spelunker_complex_or_compound_word_group)
+	catch
+	finally
+		if strlen(l:spelunker_complex_or_compound_word_hi_list) == 0 || l:spelunker_complex_or_compound_word_hi_list =~# '\v<cleared>$'
+			execute ('highlight ' . g:spelunker_complex_or_compound_word_group . ' cterm=underline ctermfg=NONE gui=underline guifg=NONE')
+		endif
+	endtry
+endfunction
+
 function! spelunker#toggle#toggle()
 	let g:enable_spelunker_vim = g:enable_spelunker_vim == 1 ? 0 : 1
 
@@ -48,6 +82,8 @@ endfunction
 
 function! spelunker#toggle#init_buffer(mode, is_enabled)
 	if a:is_enabled == 1
+		call spelunker#toggle#set_syntax()
+
 		if a:mode == 1 " for global
 			call spelunker#check()
 		elseif a:mode == 2 " for buffer

--- a/autoload/spelunker/toggle.vim
+++ b/autoload/spelunker/toggle.vim
@@ -25,7 +25,11 @@ function! spelunker#toggle#set_syntax()
 	catch
 	finally
 		if strlen(l:spelunker_spell_bad_hi_list) == 0 || l:spelunker_spell_bad_hi_list =~# '\v<cleared>$'
-			execute ('highlight ' . g:spelunker_spell_bad_group . ' ' . s:spelunker_spell_bad_style)
+			if s:spelunker_spell_bad_style =~# '^links to\>'
+				execute('highlight link ' . g:spelunker_spell_bad_group . ' ' . substitute(s:spelunker_spell_bad_style, '^links to\s*', '', ''))
+			else
+				execute('highlight '      . g:spelunker_spell_bad_group . ' ' .            s:spelunker_spell_bad_style)
+			endif
 		else
 			let s:spelunker_spell_bad_style = substitute(trim(l:spelunker_spell_bad_hi_list), '^\V' . g:spelunker_spell_bad_group . '\v\s+xxx\s+', '', '')
 		endif
@@ -47,7 +51,11 @@ function! spelunker#toggle#set_syntax()
 	catch
 	finally
 		if strlen(l:spelunker_complex_or_compound_word_hi_list) == 0 || l:spelunker_complex_or_compound_word_hi_list =~# '\v<cleared>$'
-			execute ('highlight ' . g:spelunker_complex_or_compound_word_group . ' ' . s:spelunker_complex_or_compound_word_style)
+			if s:spelunker_complex_or_compound_word_style =~# '^links to\>'
+				execute('highlight link' . g:spelunker_complex_or_compound_word_group . ' ' . substitute(s:spelunker_complex_or_compound_word_style), '^links to\s*', '', ''))
+			else
+				execute('highlight '     . g:spelunker_complex_or_compound_word_group . ' ' .            s:spelunker_complex_or_compound_word_style)
+			endif
 		else
 			let s:spelunker_complex_or_compound_word_style = substitute(trim(l:spelunker_complex_or_compound_word_hi_list), '^\V' . g:spelunker_complex_or_compound_word_group . '\v\s+xxx\+', '', '')
 		endif

--- a/plugin/spelunker.vim
+++ b/plugin/spelunker.vim
@@ -79,37 +79,7 @@ if !exists('g:spelunker_highlight_type')
 	let g:spelunker_highlight_type = g:spelunker_highlight_all
 endif
 
-" [spelunker_spell_bad_group] ===========================================================
-
-if !exists('g:spelunker_spell_bad_group')
-	let g:spelunker_spell_bad_group = 'SpelunkerSpellBad'
-endif
-
-let s:spelunker_spell_bad_hi_list = ""
-try
-	let s:spelunker_spell_bad_hi_list = execute('highlight ' . g:spelunker_spell_bad_group)
-catch
-finally
-	if strlen(s:spelunker_spell_bad_hi_list) == 0
-		execute ('highlight ' . g:spelunker_spell_bad_group . ' cterm=underline ctermfg=247 gui=underline guifg=#9E9E9E')
-	endif
-endtry
-
-" [spelunker_complex_or_compound_word_group] =======================================================
-
-if !exists('g:spelunker_complex_or_compound_word_group')
-	let g:spelunker_complex_or_compound_word_group = 'SpelunkerComplexOrCompoundWord'
-endif
-
-let s:spelunker_complex_or_compound_word_hi_list = ""
-try
-	let s:spelunker_complex_or_compound_word_hi_list = execute('highlight ' . g:spelunker_complex_or_compound_word_group)
-catch
-finally
-	if strlen(s:spelunker_complex_or_compound_word_hi_list) == 0
-		execute ('highlight ' . g:spelunker_complex_or_compound_word_group . ' cterm=underline ctermfg=NONE gui=underline guifg=NONE')
-	endif
-endtry
+call spelunker#toggle#set_syntax()
 
 " [open fix list] ========================================================================
 nnoremap <silent> <Plug>(spelunker-correct-from-list) :call spelunker#correct_from_list()<CR>


### PR DESCRIPTION
Care for https://github.com/kamykn/spelunker.vim/issues/63.

Unknown why, sometimes spellcheck highlight `SpelunkerSpellBad` and `SpelunkerComplexOrCompoundWord` can be cleared.

So, changed to set the highlightings on every spellcheck enabling.

Also, consider highlight cleared case (e.g. `:highlight clear SpelunkerSpellBad` called by someone).
The original code checks whether `:highlight SpelunkerSpellBad` output something, though,
if highlight is cleared, it outputs `SpelunkerSpellBad xxx cleared`.

With this fix, even if something goes bad,
you'll be able to reset by toggling spellcheck disabled -> enabled.
