### PR TITLE
New Option: Spellcheck Buffer Size Threshold

### DIFF
--- a/autoload/spelunker.vim
+++ b/autoload/spelunker.vim
@@ -220,6 +220,21 @@ function s:is_runnable()
 		return 0
 	endif
 
+	if exists('g:spelunker_buffer_size_threshold') && g:spelunker_buffer_size_threshold > 0
+		if exists('g:enable_spelunker_vim') && g:enable_spelunker_vim && !exists('b:enable_spelunker_vim')
+			let l:buf_size = line2byte('$') + len(getline('$'))
+			if l:buf_size > g:spelunker_buffer_size_threshold
+				let l:buf_name = bufname('%')
+				echom 'Spelunker.vim skipped this too long buffer. Do `Zt` instead:'
+						\ . ( len(l:buf_name) == 0 ? '' : ( ' buf = ''' . l:buf_name . ''',' ) )
+						\ . ' size = ' . l:buf_size . ' / ' .  g:spelunker_buffer_size_threshold
+
+				let b:enable_spelunker_vim = 0
+				return 0
+			endif
+		endif
+	endif
+
 	return 1
 endfunction
 

--- a/autoload/spelunker.vim
+++ b/autoload/spelunker.vim
@@ -220,8 +220,8 @@ function s:is_runnable()
 		return 0
 	endif
 
-	if exists('g:spelunker_buffer_size_threshold') && g:spelunker_buffer_size_threshold > 0
-		if exists('g:enable_spelunker_vim') && g:enable_spelunker_vim && !exists('b:enable_spelunker_vim')
+	if exists('g:enable_spelunker_vim') && g:enable_spelunker_vim && !exists('b:enable_spelunker_vim')
+		if exists('g:spelunker_buffer_size_threshold') && g:spelunker_buffer_size_threshold > 0
 			let l:buf_size = line2byte('$') + len(getline('$'))
 			if l:buf_size > g:spelunker_buffer_size_threshold
 				let l:buf_name = bufname('%')
@@ -232,6 +232,23 @@ function s:is_runnable()
 				let b:enable_spelunker_vim = 0
 				return 0
 			endif
+		endif
+
+		if exists('g:spelunker_buffer_max_line_width_threshold') && g:spelunker_buffer_max_line_width_threshold > 0
+			let l:line = 1
+			while l:line <= line('$')
+				let l:linewidth = len(getline(l:line))
+				if l:linewidth > g:spelunker_buffer_max_line_width_threshold
+					let l:buf_name = bufname('%')
+					echom 'Spelunker.vim skipped this too long line. Do `Zt` instead:'
+							\ . ( len(l:buf_name) == 0 ? '' : ( ' buf = ''' . l:buf_name . ''',' ) )
+							\ . ' width[' . l:line . '] = ' . l:linewidth . ' / ' .  g:spelunker_buffer_max_line_width_threshold
+
+					let b:enable_spelunker_vim = 0
+					return 0
+				endif
+				let l:line += 1
+			endwhile
 		endif
 	endif
 

--- a/autoload/spelunker/toggle.vim
+++ b/autoload/spelunker/toggle.vim
@@ -11,13 +11,9 @@ set cpo&vim
 function! spelunker#toggle#toggle()
 	let g:enable_spelunker_vim = g:enable_spelunker_vim == 1 ? 0 : 1
 
-	" 今開いているbufferも連動させる
+	" Clear the buffer-specific setting, and follow the global setting
 	if exists('b:enable_spelunker_vim')
-		if g:enable_spelunker_vim == 1
-			let b:enable_spelunker_vim = 1
-		else
-			let b:enable_spelunker_vim = 0
-		endif
+		unlet b:enable_spelunker_vim
 	endif
 
 	call spelunker#toggle#init_buffer(1, g:enable_spelunker_vim)


### PR DESCRIPTION
For performance improvement, ignore too large buffer until buffer-specific spellcheck (`Zt`) is triggered.
Just an idea for https://github.com/kamykn/spelunker.vim/issues/71. May need some more tweaks.

Introduces a new option `g:spelunker_buffer_size_threshold`.