### PR TITLE
Fix: Remove sticky styles out of Spelunker management (First aid)

### DIFF
--- a/autoload/spelunker/matches.vim
+++ b/autoload/spelunker/matches.vim
@@ -107,6 +107,16 @@ function! spelunker#matches#clear_matches()
 				\ spelunker#matches#delete_matches(keys(b:match_id_dict[l:window_id]), b:match_id_dict[l:window_id], l:window_id)
 		endfor
 	endif
+
+	" XXX: Clear sticky styles completely, even though it isn't managed in `b:match_id_dict`
+	" Side Effect: Removes all the match patterns of the Spelunker style group.
+	if exists('g:spelunker_spell_bad_group') && !empty(g:spelunker_spell_bad_group)
+		call setmatches(filter(getmatches(), 'v:val.group !=# g:spelunker_spell_bad_group'))
+	endif
+
+	if exists('g:spelunker_complex_or_compound_word_group') && !empty(g:spelunker_complex_or_compound_word_group)
+		call setmatches(filter(getmatches(), 'v:val.group !=# g:spelunker_complex_or_compound_word_group'))
+	endif
 endfunction
 
 function! spelunker#matches#clear_current_buffer_matches()
@@ -118,6 +128,16 @@ function! spelunker#matches#clear_current_buffer_matches()
 			let b:match_id_dict[l:window_id] =
 				\ spelunker#matches#delete_matches(keys(b:match_id_dict[l:window_id]), b:match_id_dict[l:window_id], l:window_id)
 		endif
+	endif
+
+	" XXX: Clear sticky styles completely, even though it isn't managed in `b:match_id_dict`
+	" Side Effect: Removes all the match patterns of the Spelunker style group.
+	if exists('g:spelunker_spell_bad_group') && !empty(g:spelunker_spell_bad_group)
+		call setmatches(filter(getmatches(), 'v:val.group !=# g:spelunker_spell_bad_group'))
+	endif
+
+	if exists('g:spelunker_complex_or_compound_word_group') && !empty(g:spelunker_complex_or_compound_word_group)
+		call setmatches(filter(getmatches(), 'v:val.group !=# g:spelunker_complex_or_compound_word_group'))
 	endif
 endfunction
 


### PR DESCRIPTION
Sometimes spell check styles unexpectedly remains.

Spelunker manages `match()` styles in `b:match_id_dict`, though,
somehow there happens to miss some styles unmanaged, probably.

For first aid,
removes the spellcheck `match()` styles of `g:spelunker_spell_bad_group` and `g:spelunker_complex_or_compound_word_group`
on clearing spellcheck matches
(Match groups `SpelunkerSpellBad` and `SpelunkerComplexOrCompoundWord`, by default).

As a side effect,
it also removes your custom `match()` settings, if the match `group` are them.
Although, generally users uses Spelunker-very-own styles, aren't they?

----

時々、スペルチェックのスタイルが 意図せず 残ること があります。

Spelunker は `match()` のスタイルを `b:match_id_dict`変数 で管理していますが、
なぜか、いくつかのスタイルが 管理されずに 取り残されること があるようです。

応急処置として：
スペルチェックの `match()`スタイル `g:spelunker_spell_bad_group` と `g:spelunker_complex_or_compound_word_group` を、
スペルチェックのマッチ箇所のクリア のタイミングで 削除するようにしました
(デフォルトでは、マッチグループ `SpelunkerSpellBad` と `SpelunkerComplexOrCompoundWord`).

副作用として：
ユーザが自分で指定した `match()`設定 についても、`group` が これらに当てはまる場合は、削除します。
でも 大抵、ユーザは Spelunker専用に スタイルを作って 使うか と思うので、あまり 問題にならないと思っています。
