### PR TITLE
Bad word pos detection in duplicated word appearance in one line

### DIFF
--- a/autoload/spelunker/spellbad.vim
+++ b/autoload/spelunker/spellbad.vim
@@ -64,6 +64,8 @@ function! spelunker#spellbad#get_word_list_in_line(line, word_list)
 		endfor
 	endwhile
 
+	call sort(l:word_list, { a, b -> len(b) - len(a) })
+
 	return l:word_list
 endfunction
 

--- a/autoload/spelunker/words.vim
+++ b/autoload/spelunker/words.vim
@@ -33,6 +33,7 @@ function! s:find_word_index_list(line_str, search_word)
 	let l:cword_length         = strlen(a:search_word)
 	let l:find_word_index_list = []
 	let l:line_str             = a:line_str
+	let l:pos                  = 0
 
 	while 1
 		let l:tmp_cword_pos = stridx(l:line_str, a:search_word)
@@ -40,8 +41,9 @@ function! s:find_word_index_list(line_str, search_word)
 			break
 		endif
 
-		call add(l:find_word_index_list, l:tmp_cword_pos)
-		let l:line_str = strpart(l:line_str, l:tmp_cword_pos + l:cword_length)
+		call add(l:find_word_index_list, l:tmp_cword_pos + l:pos)
+		let l:line_str  = strpart(l:line_str, l:tmp_cword_pos + l:cword_length)
+		let l:pos      += l:tmp_cword_pos + l:cword_length
 	endwhile
 
 	return l:find_word_index_list


### PR DESCRIPTION
For lines that have the same word duplicatedly,
it may suggest word-correct list for a different word.

```text
'foo bar' hogefuga bar
#         ^^^^^^^^
#         `ZL` here, and it shows list for `bar`.
```

It checks word position by splitting the target line, though,
it has not considered the length of cut part.
