### PR TITLE
Single word correction (`Zl`) can fail without `&wrapscan`

### DIFF
--- a/autoload/spelunker/words.vim
+++ b/autoload/spelunker/words.vim
@@ -118,7 +118,11 @@ function! spelunker#words#replace_word(target_word, replace_word, is_correct_all
 		execute "silent! %s/\\v([A-Z]@<!)" . a:target_word . "([a-z]@!)\\C/". a:replace_word . "/g"
 	else
 		let l:right_move = strlen(a:target_word) - 1
+		let l:wrapscan = &wrapscan
+		let &wrapscan = v:true
 		execute "silent! normal! /" . a:target_word . "\<CR>Nv" . l:right_move . "lc" . a:replace_word
+		let &wrapscan = l:wrapscan
+		unlet! l:wrapscan
 	endif
 
 	call setpos('.', l:pos)


### PR DESCRIPTION

## How to repro

Run `Zl` at the pos below:

```text
CORSS.CORSS
      ^
```

It happens if

* `&wrapscan` is disabled (`set nowrapscan`)
* The wrong words appear more than once in the buffer
* Cursor is on the beginning of the last word

## Why this happens

In single word correction in `spelunker#words#replace_word()`,
it does `/SERCHWORD/`, `N` (move to previous word), and change the target word.

With `&wrapscan` (successful case),
it does `/SEARCHWORD/` to move the next word, and comes back to the target word by `N`.

Without `&wrapscan` (bad case),
since the target word is the last appearance in the buf,
the `/SEARCHWORD/` command fails, and cursor keeps its position.
So, if the cursor is on the beggining of the word,
the following `N` command jumps to the word before the target unexpectedly.

To fix this instantly, set `&wrapscan` in the operation.
