### PR TITLE
Clear `match_id_dict` even if `matchdelete()` fails.

### DIFF
--- a/autoload/spelunker/matches.vim
+++ b/autoload/spelunker/matches.vim
@@ -86,11 +86,9 @@ function! spelunker#matches#delete_matches(word_list_for_delete, match_id_dict, 
 					let l:is_ok = matchdelete(l:delete_match_id)
 				endif
 			finally
-				if l:is_ok == 0
-					let l:del_index = index(values(l:match_id_dict), l:delete_match_id)
-					if l:del_index != -1
-						call remove(l:match_id_dict, keys(l:match_id_dict)[l:del_index])
-					endif
+				let l:del_index = index(values(l:match_id_dict), l:delete_match_id)
+				if l:del_index != -1
+					call remove(l:match_id_dict, keys(l:match_id_dict)[l:del_index])
 				endif
 			endtry
 		endif


### PR DESCRIPTION
Reset `match_id_dict` of spelunker-internal highlight dictionary, even if `matchdelete()` fails.

Now, match id is left if `matchdelete()` fails;
but it is the case that the match highlight has already gone.

Allow users to reset the match state by turning spelunker off and on, it should be cleared up.
