### PR TITLE
Don't use `:redir` as this can't be nested in `execute()`

### DIFF
--- a/autoload/spelunker.vim
+++ b/autoload/spelunker.vim
@@ -161,9 +161,7 @@ endfunction
 
 " 処理前のspell設定を取得
 function! spelunker#get_current_spell_setting()
-	redir => spell_setting_capture
-		silent execute "setlocal spell?"
-	redir END
+	let l:spell_setting_capture = execute("setlocal spell?")
 
 	" ex) '      spell' -> 'spell'
 	return substitute(l:spell_setting_capture, '\v(\n|\s)\C', '', 'g')

--- a/autoload/spelunker/jump.vim
+++ b/autoload/spelunker/jump.vim
@@ -145,9 +145,7 @@ function s:get_end_of_line(is_search_next)
 endfunction
 
 function s:is_enable_wrapscan()
-	redir => wrapscan_setting_capture
-	silent execute "set wrapscan?"
-	redir END
+	let l:wrapscan_setting_capture = execute("set wrapscan?")
 
 	" ex) '      wrapscan' -> 'wrapscan'
 	let l:wrapscan_setting_capture = substitute(l:wrapscan_setting_capture, '\v(\n|\s)\C', '', 'g')


### PR DESCRIPTION
Before this change, e.g. `:call execute("edit foo.txt")` resulted in an error, but works now.